### PR TITLE
Expose notification Guzzle response objects

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -3,10 +3,10 @@
 namespace NotificationChannels\Fcm;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
+use Psr\Http\Message\ResponseInterface;
 
 class FcmChannel
 {
@@ -29,7 +29,7 @@ class FcmChannel
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
      *
-     * @return Response[]
+     * @return ResponseInterface[]
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
@@ -69,7 +69,7 @@ class FcmChannel
 
     /**
      * @param $fcmMessage
-     * @return Response|void
+     * @return ResponseInterface
      * @throws CouldNotSendNotification
      */
     protected function sendToFcm($fcmMessage)

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -64,6 +64,7 @@ class FcmChannel
                 $responses[] = $this->sendToFcm($fcmMessage);
             }
         }
+
         return $responses;
     }
 

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -28,6 +28,7 @@ class FcmChannel
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
      *
+     * @return array|void
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
@@ -62,10 +63,7 @@ class FcmChannel
                 $responses[] = $this->sendToFcm($fcmMessage);
             }
         }
-
-        if (method_exists($notifiable, 'storeResponses')) {
-            $notifiable->storeResponses($responses);
-        }
+        return $responses;
     }
 
     protected function sendToFcm($fcmMessage)

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Fcm;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
@@ -28,7 +29,7 @@ class FcmChannel
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
      *
-     * @return array|void
+     * @return Response[]
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
@@ -66,6 +67,11 @@ class FcmChannel
         return $responses;
     }
 
+    /**
+     * @param $fcmMessage
+     * @return Response|void
+     * @throws CouldNotSendNotification
+     */
     protected function sendToFcm($fcmMessage)
     {
         try {


### PR DESCRIPTION
Capture all Guzzle responses into an array and then if the $notifiable object has a method to storeResponses we'll pass it to the notifiable. Then, a user can capture the notification sent event and log these responses or check if the response was sent successfully or not.