### PR TITLE
Empty FCM tokens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class AccountActivated extends Notification
 }
 ```
 
-You will have to set a `routeNotificationForFcm()` method in your notifiable model. For example:
+You will have to set a `routeNotificationForFcm()` method in your notifiable model, wich will return one or an array of tokens. For example:
 
 ```php
 class User extends Authenticatable


### PR DESCRIPTION
References  #18 

Contains support for empty fcm tokens. This will always cast the result of `routeNotificationForFcm()` to an array. Therefore the send method of the `FcmChannel` class can be used in a similar way like: [https://github.com/laravel-notification-channels/apn](url)