### PR TITLE
make routeNotificationFor method accepts notification object

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -30,7 +30,7 @@ class FcmChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $token = $notifiable->routeNotificationFor('fcm');
+        $token = $notifiable->routeNotificationFor('fcm', $notification);
 
         if (empty($token)) {
             return [];


### PR DESCRIPTION
I have a situation that I want to check the notification type in the `routeNotificationFor()` method