### PR TITLE
Added Laravel 8.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=7.1.3",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
-        "illuminate/notifications": "~5.6 || ~6.0 || ~7.0",
-        "illuminate/support": "~5.6 || ~6.0 || ~7.0",
+        "illuminate/notifications": "~5.6 || ~6.0 || ~7.0 || ~8.0",
+        "illuminate/support": "~5.6 || ~6.0 || ~7.0 || ~8.0",
         "kreait/laravel-firebase": "^1.3 || ^2.1",
         "spatie/enum": "^2.3 || ^3.0"
     },


### PR DESCRIPTION
With [laravel-firebase 2.3.0](https://github.com/kreait/laravel-firebase/releases/tag/2.3.0) adding laravel 8.x support, this should be ready for the upgrade.

closes #54 