### PR TITLE
Add failed notification event

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -2,12 +2,23 @@
 
 namespace NotificationChannels\Fcm\Exceptions;
 
+use Exception;
 use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\Message;
 
-class CouldNotSendNotification extends \Exception
+class CouldNotSendNotification extends Exception
 {
-    public static function serviceRespondedWithAnError(MessagingException $messagingException)
+    public static function serviceRespondedWithAnError(MessagingException $exception)
     {
-        return new static($messagingException->getMessage());
+        return new static(
+            $exception->getMessage(),
+            $exception->getCode(),
+            $exception
+        );
+    }
+
+    public static function invalidMessage()
+    {
+        return new static('The toFcm() method only accepts instances of ' . Message::class);
     }
 }

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -2,12 +2,11 @@
 
 namespace NotificationChannels\Fcm;
 
-use GuzzleHttp\Client;
 use Illuminate\Notifications\Notification;
 use Kreait\Firebase\Exception\MessagingException;
 use Kreait\Firebase\Messaging\CloudMessage;
 use Kreait\Firebase\Messaging\Message;
-use Kreait\Laravel\Firebase\Facades\FirebaseMessaging;
+use Kreait\Firebase\Messaging as MessagingClient;
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 
 class FcmChannel
@@ -15,9 +14,19 @@ class FcmChannel
     const MAX_TOKEN_PER_REQUEST = 500;
 
     /**
-     * @var Client
+     * @var MessagingClient
      */
     protected $client;
+
+    /**
+     * FcmChannel constructor.
+     *
+     * @param MessagingClient $client
+     */
+    public function __construct(MessagingClient $client)
+    {
+        $this->client = $client;
+    }
 
     /**
      * Send the given notification.
@@ -75,7 +84,7 @@ class FcmChannel
     protected function sendToFcm(Message $fcmMessage)
     {
         try {
-            return FirebaseMessaging::send($fcmMessage);
+            return $this->client->send($fcmMessage);
         } catch (MessagingException $messagingException) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($messagingException);
         }
@@ -91,7 +100,7 @@ class FcmChannel
     protected function sendToFcmMulticast($fcmMessage, $tokens)
     {
         try {
-            return FirebaseMessaging::sendMulticast($fcmMessage, $tokens);
+            return $this->client->sendMulticast($fcmMessage, $tokens);
         } catch (MessagingException $messagingException) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($messagingException);
         }


### PR DESCRIPTION
Hi @chrisbjr,

This PR brings many improvements.

* Use dependency injection for FCM Messaging client, so that we can mock it during testing 💪 
* De-dupe  the try/catch logic in channel class 🧰 
* Dispatch `Illuminate\Notifications\Events\NotificationFailed` event on failure so that package consumers can take actions on it. 🚀 

#### Note
* `MessagingClient` and `Dispatcher` implementations will be automatically resolved by Laravel IOC.
* This is no breaking change in this PR, Every thing should work as before.

The repo does not have any test cases yet, i am planning to submit tests once this PR gets merged. 😄 