### PR TITLE
Fix Catch Exception when resolving FirebaseManager

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -10,6 +10,7 @@ use Kreait\Firebase\Exception\MessagingException;
 use Kreait\Firebase\Messaging\CloudMessage;
 use Kreait\Firebase\Messaging\Message;
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
+use ReflectionException;
 use Throwable;
 
 class FcmChannel
@@ -94,6 +95,8 @@ class FcmChannel
         try {
             $messaging = app('firebase.manager')->project($this->fcmProject)->messaging();
         } catch (BindingResolutionException $e) {
+            $messaging = app('firebase.messaging');
+        } catch (ReflectionException $e) {
             $messaging = app('firebase.messaging');
         }
 


### PR DESCRIPTION
My Case is the Following:

- I'm working with laravel v5.8 (a Legacy project and can't upgrade it now).

- I installed this package with version v2.2

- The Package using `laravel-firebase` with version v2.4 which support laravel v5.8

My Problem:
- Because `laravel-firebase`  v2.4 installed this version didn't bind `firebase.manager` in laravel service container
- This means it should fallback and enter the catch block and use `firebase.messaging`.
- But the problem is the catch block trying catch `BindingResolutionException` but in my case, the exception was `ReflectionException`.
- I don't know what is the problem maybe because I'm working with the old laravel version but I hope you find this solution helpful.


Error Message image:
![Screenshot 2020-12-21 110620](https://user-images.githubusercontent.com/22417282/102759334-a4833500-437c-11eb-8292-b72df1498c7b.png)
