### PR TITLE
Fix null token from routeNotificationFor

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -17,6 +17,11 @@ class CouldNotSendNotification extends Exception
         );
     }
 
+    public static function invalidToken()
+    {
+        return new static('The notifiable did not have a fcm token.');
+    }
+
     public static function invalidMessage()
     {
         return new static('The toFcm() method only accepts instances of ' . Message::class);

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -48,11 +48,7 @@ class FcmChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $token = $notifiable->routeNotificationFor('fcm', $notification);
-
-        if (empty($token)) {
-            return [];
-        }
+        $token = $this->getToken($notifiable);
 
         // Get the message from the notification class
         $fcmMessage = $notification->toFcm($notifiable);
@@ -84,6 +80,29 @@ class FcmChannel
         }
 
         return $responses;
+    }
+
+    /**
+     * @param $notifiable
+     *
+     * @return mixed
+     * @throws CouldNotSendNotification
+     */
+    protected function getToken($notifiable)
+    {
+        if ($notifiable->routeNotificationFor(self::class)) {
+            return $notifiable->routeNotificationFor(self::class);
+        }
+
+        if ($notifiable->routeNotificationFor('fcm')) {
+            return $notifiable->routeNotificationFor('fcm');
+        }
+
+        if (isset($notifiable->fcm_token)) {
+            return $notifiable->fcm_token;
+        }
+
+        throw CouldNotSendNotification::invalidToken();
     }
 
     /**


### PR DESCRIPTION
The **toFcm method is never called** when using the `Notification::route(FcmChannel::class, $user->notification_token)->notify(new ExampleNotify($object));` method. We don't get an error message.