### PR TITLE
Allow ApnsFcmOptions to be nullable

### DIFF
--- a/src/Resources/ApnsConfig.php
+++ b/src/Resources/ApnsConfig.php
@@ -66,9 +66,9 @@ class ApnsConfig implements FcmResource
     }
 
     /**
-     * @return ApnsFcmOptions
+     * @return ApnsFcmOptions|null
      */
-    public function getFcmOptions(): ApnsFcmOptions
+    public function getFcmOptions(): ?ApnsFcmOptions
     {
         return $this->fcmOptions;
     }


### PR DESCRIPTION
**Problem**
If you set a payload on the `apnsconfig` object without setting `fcmoption` also, I receive a fatal error due to the typehinting on `getFcmOptions`. Where `null` is not an accepted return type.

However, looking at `\NotificationChannels\Fcm\Resources\ApnsConfig::toArray`, the code explicitly checks if `getFcmOptions` is null, therefore it seems as though the return of this function can be null.


**Solution**
Loosen the typehinting on src/Resources/ApnsConfig::getFcmOptions

**Contribution Notes**
The contribution guide does not seem to be followed, it mentions test coverage, change log updates etc however the current codebase does not contain test coverage or change log updates, therefore I have opted out of this, hopefully this is not an issue - we need to update the contribution docs.
