### PR TITLE
Removed :mixed type from jsonSerialize method

### DIFF
--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -272,7 +272,7 @@ class FcmMessage implements Message
         ];
     }
 
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }


### PR DESCRIPTION
Fixed instance of array in returned value when dispatching the notification.

`json_encode error: Return value of NotificationChannels\Fcm\FcmMessage::jsonSerialize() must be an instance of NotificationChannels\Fcm\mixed, array returned` 

Closes #104 
