### PR TITLE
Added validation for anything other than a string in setData

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -24,6 +24,6 @@ class CouldNotSendNotification extends Exception
 
     public static function invalidPropertyInArray($key)
     {
-        return new static("The value of ".$key." must be a string");
+        return new static('The value of ' . $key . ' must be a string');
     }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -21,4 +21,9 @@ class CouldNotSendNotification extends Exception
     {
         return new static('The toFcm() method only accepts instances of ' . Message::class);
     }
+
+    public static function invalidPropertyInArray($key)
+    {
+        return new static("The value of ".$key." must be a string");
+    }
 }

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -3,12 +3,12 @@
 namespace NotificationChannels\Fcm;
 
 use Kreait\Firebase\Messaging\Message;
+use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Fcm\Resources\AndroidConfig;
 use NotificationChannels\Fcm\Resources\ApnsConfig;
 use NotificationChannels\Fcm\Resources\FcmOptions;
 use NotificationChannels\Fcm\Resources\Notification;
 use NotificationChannels\Fcm\Resources\WebpushConfig;
-use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 
 class FcmMessage implements Message
 {
@@ -97,12 +97,13 @@ class FcmMessage implements Message
     /**
      * @param  array|null  $data
      * @return FcmMessage
+     * 
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
-        foreach($data as $key => $item){
-            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        foreach ($data as $key => $item) {
+            ! is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : '';
         }
 
         $this->data = $data;

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -8,6 +8,7 @@ use NotificationChannels\Fcm\Resources\ApnsConfig;
 use NotificationChannels\Fcm\Resources\FcmOptions;
 use NotificationChannels\Fcm\Resources\Notification;
 use NotificationChannels\Fcm\Resources\WebpushConfig;
+use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 
 class FcmMessage implements Message
 {
@@ -96,9 +97,14 @@ class FcmMessage implements Message
     /**
      * @param  array|null  $data
      * @return FcmMessage
+     * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
+        foreach($data as $key => $item){
+            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        }
+
         $this->data = $data;
 
         return $this;

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -97,7 +97,7 @@ class FcmMessage implements Message
     /**
      * @param  array|null  $data
      * @return FcmMessage
-     * 
+     *
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self

--- a/src/Resources/AndroidConfig.php
+++ b/src/Resources/AndroidConfig.php
@@ -136,7 +136,7 @@ class AndroidConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return AndroidConfig
-     * 
+     *
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
@@ -144,7 +144,7 @@ class AndroidConfig implements FcmResource
         foreach ($data as $key => $item) {
             ! is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : '';
         }
-   
+
         $this->data = $data;
 
         return $this;

--- a/src/Resources/AndroidConfig.php
+++ b/src/Resources/AndroidConfig.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Fcm\Resources;
 
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
+
 class AndroidConfig implements FcmResource
 {
     /**
@@ -135,14 +136,15 @@ class AndroidConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return AndroidConfig
+     * 
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
-        foreach($data as $key => $item){
-            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        foreach ($data as $key => $item) {
+            ! is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : '';
         }
-        
+   
         $this->data = $data;
 
         return $this;

--- a/src/Resources/AndroidConfig.php
+++ b/src/Resources/AndroidConfig.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Fcm\Resources;
 
+use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 class AndroidConfig implements FcmResource
 {
     /**
@@ -134,9 +135,14 @@ class AndroidConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return AndroidConfig
+     * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
+        foreach($data as $key => $item){
+            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        }
+        
         $this->data = $data;
 
         return $this;

--- a/src/Resources/WebpushConfig.php
+++ b/src/Resources/WebpushConfig.php
@@ -64,7 +64,7 @@ class WebpushConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return WebpushConfig
-     * 
+     *
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self

--- a/src/Resources/WebpushConfig.php
+++ b/src/Resources/WebpushConfig.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace NotificationChannels\Fcm\Resources;
-
+use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 class WebpushConfig implements FcmResource
 {
     /**
@@ -62,9 +62,14 @@ class WebpushConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return WebpushConfig
+     * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
+        foreach($data as $key => $item){
+            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        }
+        
         $this->data = $data;
 
         return $this;

--- a/src/Resources/WebpushConfig.php
+++ b/src/Resources/WebpushConfig.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace NotificationChannels\Fcm\Resources;
+
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
+
 class WebpushConfig implements FcmResource
 {
     /**
@@ -62,14 +64,15 @@ class WebpushConfig implements FcmResource
     /**
      * @param  array|null  $data
      * @return WebpushConfig
+     * 
      * @throws \NotificationChannels\Fcm\Exceptions\CouldNotSendNotification
      */
     public function setData(?array $data): self
     {
-        foreach($data as $key => $item){
-            !is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : ''; 
+        foreach ($data as $key => $item) {
+            ! is_string($item) ? throw CouldNotSendNotification::invalidPropertyInArray($key) : '';
         }
-        
+
         $this->data = $data;
 
         return $this;


### PR DESCRIPTION
# What's inside 

Passing anything through other than a string in SetData causes the push notification to not be received.
```
return FcmMessage::create()
            ->setData([
                'foo' => 'bar',
                '1' => 2,
            ])
            ->setNotification(
                \NotificationChannels\Fcm\Resources\Notification::create()
                    ->setTitle('title')
                    ->setBody('body')
            );
```
<br/>
This PR:

- Added validation for anything other than a string in `setData` method
- Resolves #77 
