### PR TITLE
Add more specific parameter type for `setData()` method

### DIFF
--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -94,7 +94,7 @@ class FcmMessage implements Message
     }
 
     /**
-     * @param  array|null  $data
+     * @param  array<string, string>|null  $data
      * @return FcmMessage
      */
     public function setData(?array $data): self


### PR DESCRIPTION
FCM message will not be received if array shape is different from `array<string, string>` (string keys and string values).

For example, this code won’t work:
```php
return FcmMessage::create()
	->setData([
		'string_key1' => 'string_value1',
		'string_key2' => 'string_value1',
		'string_key3' => 666, // integer value
	])->...
```

I propose to specify an array shape for the parameter of `setData()` method in order to help IDEs to analyse the code and to highlight possible errors preemptively. This will save developers’ time (I personally spent on this issue a couple of investigation hours).