### PR TITLE
Fix for "A message can only have one of the following targets" error

### DIFF
--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -258,7 +258,7 @@ class FcmMessage implements Message
 
     public function toArray()
     {
-        return [
+        $data = [
             'name' => $this->getName(),
             'data' => $this->getData(),
             'notification' => ! is_null($this->getNotification()) ? $this->getNotification()->toArray() : null,
@@ -266,10 +266,21 @@ class FcmMessage implements Message
             'webpush' => ! is_null($this->getWebpush()) ? $this->getWebpush()->toArray() : null,
             'apns' => ! is_null($this->getApns()) ? $this->getApns()->toArray() : null,
             'fcm_options' => ! is_null($this->getFcmOptions()) ? $this->getFcmOptions()->toArray() : null,
-            'token' => $this->getToken(),
-            'topic' => $this->getTopic(),
-            'condition' => $this->getCondition(),
         ];
+
+        if ($token = $this->getToken()) {
+            $data['token'] = $token;
+        }
+
+        if ($topic = $this->getTopic()) {
+            $data['topic'] = $topic;
+        }
+
+        if ($condition = $this->getCondition()) {
+            $data['condition'] = $condition;
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
https://github.com/kreait/firebase-php/blob/6.x/src/Firebase/Messaging/CloudMessage.php#L75

It checks array keys but does not check if they are empty or not, so it causes "A message can only have one of the following targets: condition, token, topic, unknown" error.