### PR TITLE
Pass token to notification failed event

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -80,7 +80,7 @@ class FcmChannel
                 $responses[] = $this->sendToFcm($fcmMessage, $token);
             }
         } catch (MessagingException $exception) {
-            $this->failedNotification($notifiable, $notification, $exception);
+            $this->failedNotification($notifiable, $notification, $exception, $token);
             throw CouldNotSendNotification::serviceRespondedWithAnError($exception);
         }
 
@@ -143,9 +143,10 @@ class FcmChannel
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
      * @param  \Throwable  $exception
+     * @param  string|array  $token
      * @return array|null
      */
-    protected function failedNotification($notifiable, Notification $notification, Throwable $exception)
+    protected function failedNotification($notifiable, Notification $notification, Throwable $exception, $token)
     {
         return $this->events->dispatch(new NotificationFailed(
             $notifiable,
@@ -154,6 +155,7 @@ class FcmChannel
             [
                 'message' => $exception->getMessage(),
                 'exception' => $exception,
+                'token' => $token,
             ]
         ));
     }


### PR DESCRIPTION
This commit adds the token value to the NotificationFailed $data parameter.

_Context:_ 
In our use case, we need to remove the token from our database when a notification fails due to a token being either expired or invalid. 
Having this value passed in the event is safer than trying to retrieve said token from database as retrieving it could be subject to race conditions at scale (example: while notification is attempted, token is updated in database by user, notification fails then deletes the new token instead of the one that actually failed)