### PR TITLE
L10 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2]
-        laravel: [9.*]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle": "^7.0",
         "illuminate/notifications": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
-        "kreait/laravel-firebase": "^5.0"
+        "kreait/laravel-firebase": "^5.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.5.1",


### PR DESCRIPTION
Hi!

This PR adds support for Laravel 10.

It bumps `kreait/laravel-firebase` to `5.1` (the versions that supports L10)
and add the matrix for laravel 10.x