### PR TITLE
Fix enum values

### DIFF
--- a/src/Resources/Visibility.php
+++ b/src/Resources/Visibility.php
@@ -4,7 +4,7 @@ namespace NotificationChannels\Fcm\Resources;
 
 enum Visibility: string
 {
-    case VISIBILITY_UNSPECIFIED = 'PRIVATE';
+    case VISIBILITY_UNSPECIFIED = 'UNSPECIFIED';
     case VISIBILITY_PRIVATE = 'PRIVATE';
     case VISIBILITY_PUBLIC = 'PUBLIC';
     case VISIBILITY_SECRET = 'SECRET';

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class FcmChannelTest extends TestCase
 {
     /** @test */
-    public function true_is_true()
+    public function it_can_be_instantiated()
     {
         $events = Mockery::mock(Dispatcher::class);
 

--- a/tests/Resources/AndroidMessagePriorityTest.php
+++ b/tests/Resources/AndroidMessagePriorityTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NotificationChannels\Fcm\Test\Resources;
+
+use NotificationChannels\Fcm\Resources\AndroidMessagePriority;
+use PHPUnit\Framework\TestCase;
+
+class AndroidMessagePriorityTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_instantiated()
+    {
+        $instance = AndroidMessagePriority::NORMAL;
+
+        $this->assertInstanceOf(AndroidMessagePriority::class, $instance);
+    }
+}

--- a/tests/Resources/NotificationPriorityTest.php
+++ b/tests/Resources/NotificationPriorityTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NotificationChannels\Fcm\Test\Resources;
+
+use NotificationChannels\Fcm\Resources\NotificationPriority;
+use PHPUnit\Framework\TestCase;
+
+class NotificationPriorityTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_instantiated()
+    {
+        $instance = NotificationPriority::PRIORITY_UNSPECIFIED;
+
+        $this->assertInstanceOf(NotificationPriority::class, $instance);
+    }
+}

--- a/tests/Resources/VisibilityTest.php
+++ b/tests/Resources/VisibilityTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NotificationChannels\Fcm\Test\Resources;
+
+use NotificationChannels\Fcm\Resources\Visibility;
+use PHPUnit\Framework\TestCase;
+
+class VisibilityTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_instantiated()
+    {
+        $instance = Visibility::VISIBILITY_PUBLIC;
+
+        $this->assertInstanceOf(Visibility::class, $instance);
+    }
+}


### PR DESCRIPTION
I think when I [converted this from the previous enum implementation to the native implemenation](https://github.com/laravel-notification-channels/fcm/pull/130/files#diff-24914973021d322ee9048f6fc89dfae5e4bbc8b3d56eff8a30da88b4ed9a1427) I made a mistake by setting unspecified to private as well.

* This fixes the enum by setting the value of the string to match the case,
* It also adds test coverage for this and the other enum values.

Closes #141