### PR TITLE
Add macroable trait to FcmMessage class

### DIFF
--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Fcm;
 
+use Illuminate\Support\Traits\Macroable;
 use Kreait\Firebase\Messaging\Message;
 use NotificationChannels\Fcm\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Fcm\Resources\AndroidConfig;
@@ -12,6 +13,8 @@ use NotificationChannels\Fcm\Resources\WebpushConfig;
 
 class FcmMessage implements Message
 {
+    use Macroable;
+    
     /**
      * @var string|null
      */

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -14,7 +14,7 @@ use NotificationChannels\Fcm\Resources\WebpushConfig;
 class FcmMessage implements Message
 {
     use Macroable;
-    
+
     /**
      * @var string|null
      */


### PR DESCRIPTION
In all my fcm notifications, I create an FcmMessage object with the same AndroidConfig and ApnsConfig. It would be nice if I could create a macro that makes it possible to hide that shared code.
```php
return FcmMessage::create()
	->default() // macro that sets android and apns config
	->...

// Instead of having to duplicate those configs in every notification
return FcmMessage::create()
	->...
    ->setAndroid(
        AndroidConfig::create()->...
    )->setApns(
        ApnsConfig::create()->...
    );
```