### PR TITLE
Exclude development files from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,11 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.editorconfig      export-ignore
 /.gitattributes     export-ignore
+/.github            export-ignore
 /.gitignore         export-ignore
+/.styleci.yml       export-ignore
 /.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore


### PR DESCRIPTION
This PR makes it so that this repository's development files aren't included in future releases.