### PR TITLE
Fix support for push notifications to topics and conditions

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -103,7 +103,7 @@ class FcmChannel
 
     /**
      * @param  \Kreait\Firebase\Messaging\Message  $fcmMessage
-     * @param $token
+     * @param  $token
      * @return array
      *
      * @throws \Kreait\Firebase\Exception\MessagingException
@@ -123,7 +123,7 @@ class FcmChannel
     }
 
     /**
-     * @param $fcmMessage
+     * @param  $fcmMessage
      * @param  array  $tokens
      * @return \Kreait\Firebase\Messaging\MulticastSendReport
      *


### PR DESCRIPTION
Currently, sending push notifications to a topic or conditions is impossible.
```php
Notification::route(FcmChannel::class, null)->notify(new SomePushNotification());

// -----

class SomePushNotification extends Notification
{
    public function via() : array
    {
        return [FcmChannel::class];
    }

    public function toFcm()
    {
        return FcmMessage::create()
		    ->setNotification(
		        \NotificationChannels\Fcm\Resources\Notification::create()
		            ->setTitle('hello world!')
		            ->setBody('this is a push notification sent from the server to a firebase topic')
		    )
		    ->setTopic('foo');
	}
}
```

This is caused by the fact that the `FcmChannel` class immediately aborts if there are no tokens:
https://github.com/laravel-notification-channels/fcm/blob/fa5e63d167f2d4a6e8ce01a2c8ea58553681e84e/src/FcmChannel.php#L46-L52

This PR fixes that.