### PR TITLE
Remove ability to change client or project on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,6 @@ class AccountActivated extends Notification
                 ApnsConfig::create()
                     ->setFcmOptions(ApnsFcmOptions::create()->setAnalyticsLabel('analytics_ios')));
     }
-
-    // optional method when using kreait/laravel-firebase:^3.0, this method can be omitted, defaults to the default project
-    public function fcmProject($notifiable, $message)
-    {
-        // $message is what is returned by `toFcm`
-        return 'app'; // name of the firebase project to use
-    }
 }
 ```
 

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -2,14 +2,13 @@
 
 namespace NotificationChannels\Fcm;
 
+use Firebase\Contract\Messaging;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
-use Kreait\Firebase\Messaging\Message;
 use Kreait\Firebase\Messaging\MulticastSendReport;
 use Kreait\Firebase\Messaging\SendReport;
-use Firebase\Contract\Messaging;
 
 class FcmChannel
 {

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -68,7 +68,7 @@ class FcmChannel
     {
         collect($report->getItems())
             ->filter(fn (SendReport $report) => $report->isFailure())
-            ->each(function (SendReport $report) {
+            ->each(function (SendReport $report) use ($notifiable, $notification) {
                 $this->failedNotification($notifiable, $notification, $report);
             });
     }

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -34,11 +34,6 @@ class FcmChannel
     }
 
     /**
-     * @var string|null
-     */
-    protected $fcmProject = null;
-
-    /**
      * Send the given notification.
      *
      * @param  mixed  $notifiable
@@ -53,13 +48,7 @@ class FcmChannel
             return;
         }
 
-        // Get the message from the notification class
         $fcmMessage = $notification->toFcm($notifiable);
-
-        $this->fcmProject = null;
-        if (method_exists($notification, 'fcmProject')) {
-            $this->fcmProject = $notification->fcmProject($notifiable, $fcmMessage);
-        }
 
         collect($tokens)
             ->chunk(self::TOKENS_PER_REQUEST)

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -3,18 +3,17 @@
 namespace NotificationChannels\Fcm\Test;
 
 use Exception;
-use NotificationChannels\Fcm\FcmMessage;
+use Firebase\Contract\Messaging;
 use Illuminate\Contracts\Events\Dispatcher;
-use Mockery;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Kreait\Firebase\Messaging\MessageTarget;
 use Kreait\Firebase\Messaging\MulticastSendReport;
 use Kreait\Firebase\Messaging\SendReport;
-use Kreait\Firebase\Messaging\MessageTarget;
-use Illuminate\Notifications\Notification;
-use Illuminate\Notifications\Notifiable;
+use Mockery;
 use NotificationChannels\Fcm\FcmChannel;
+use NotificationChannels\Fcm\FcmMessage;
 use PHPUnit\Framework\TestCase;
-
-use Firebase\Contract\Messaging;
 
 class FcmChannelTest extends TestCase
 {
@@ -58,7 +57,7 @@ class FcmChannelTest extends TestCase
 
         $firebase = Mockery::mock(Messaging::class, [
             'sendMulticast' => MulticastSendReport::withItems([
-                SendReport::failure($this->target(), new Exception)
+                SendReport::failure($this->target(), new Exception),
             ]),
         ]);
 

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -2,20 +2,62 @@
 
 namespace NotificationChannels\Fcm\Test;
 
+use NotificationChannels\Fcm\FcmMessage;
 use Illuminate\Contracts\Events\Dispatcher;
 use Mockery;
+use Kreait\Firebase\Messaging\MulticastSendReport;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Notifiable;
 use NotificationChannels\Fcm\FcmChannel;
 use PHPUnit\Framework\TestCase;
+use Firebase\Contract\Messaging;
 
 class FcmChannelTest extends TestCase
 {
-    /** @test */
-    public function it_can_be_instantiated()
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_it_can_be_instantiated()
     {
         $events = Mockery::mock(Dispatcher::class);
+        $firebase = Mockery::mock(Messaging::class);
 
-        $channel = new FcmChannel($events);
+        $channel = new FcmChannel($events, $firebase);
 
         $this->assertInstanceOf(FcmChannel::class, $channel);
+    }
+
+    public function test_it_can_send_notifications()
+    {
+        $events = Mockery::mock(Dispatcher::class);
+        $firebase = Mockery::mock(Messaging::class, [
+            'sendMulticast' => MulticastSendReport::withItems([]),
+        ]);
+
+        $channel = new FcmChannel($events, $firebase);
+
+        $channel->send(new DummyNotifiable, new DummyNotification);
+
+        Mockery::close();
+    }
+}
+
+class DummyNotification extends Notification
+{
+    public function toFcm($notifiable)
+    {
+        return new FcmMessage;
+    }
+}
+
+class DummyNotifiable
+{
+    use Notifiable;
+
+    public function routeNotificationForFcm($notification)
+    {
+        return ['token'];
     }
 }

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -2,14 +2,18 @@
 
 namespace NotificationChannels\Fcm\Test;
 
+use Exception;
 use NotificationChannels\Fcm\FcmMessage;
 use Illuminate\Contracts\Events\Dispatcher;
 use Mockery;
 use Kreait\Firebase\Messaging\MulticastSendReport;
+use Kreait\Firebase\Messaging\SendReport;
+use Kreait\Firebase\Messaging\MessageTarget;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Notifiable;
 use NotificationChannels\Fcm\FcmChannel;
 use PHPUnit\Framework\TestCase;
+
 use Firebase\Contract\Messaging;
 
 class FcmChannelTest extends TestCase
@@ -32,15 +36,42 @@ class FcmChannelTest extends TestCase
     public function test_it_can_send_notifications()
     {
         $events = Mockery::mock(Dispatcher::class);
+        $events->shouldNotReceive('dispatch');
+
         $firebase = Mockery::mock(Messaging::class, [
-            'sendMulticast' => MulticastSendReport::withItems([]),
+            'sendMulticast' => MulticastSendReport::withItems([
+                SendReport::success($this->target(), []),
+            ]),
         ]);
 
         $channel = new FcmChannel($events, $firebase);
 
-        $channel->send(new DummyNotifiable, new DummyNotification);
+        $result = $channel->send(new DummyNotifiable, new DummyNotification);
 
-        Mockery::close();
+        $this->assertNull($result);
+    }
+
+    public function test_it_can_dispatch_events()
+    {
+        $events = Mockery::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once();
+
+        $firebase = Mockery::mock(Messaging::class, [
+            'sendMulticast' => MulticastSendReport::withItems([
+                SendReport::failure($this->target(), new Exception)
+            ]),
+        ]);
+
+        $channel = new FcmChannel($events, $firebase);
+
+        $result = $channel->send(new DummyNotifiable, new DummyNotification);
+
+        $this->assertNull($result);
+    }
+
+    protected function target()
+    {
+        return MessageTarget::with(MessageTarget::TOKEN, 'token');
     }
 }
 


### PR DESCRIPTION
The ability to swap out the messaging client or the app project on the fly results in a lot of additional code and also makes it difficult to test. Considering that the **vast majority** of users of this channel won't use these features let's instead support the simplest use case comfortably.