### PR TITLE
Allow using custom clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package makes it easy to send notifications using [Firebase Cloud Messaging
 	- [Setting up the FCM service](#setting-up-the-fcm-service)
 - [Usage](#usage)
 	- [Available message methods](#available-message-methods)
+    - [Custom clients](#custom-clients)
     - [Handling errors](#handling-errors)
 - [Changelog](#changelog)
 - [Testing](#testing)
@@ -170,6 +171,19 @@ setTopic(string $topic)
 
 ```php
 setCondition(string $condition)
+```
+
+## Custom clients
+
+You can change the underlying Firebase Messaging client on the fly if required. Provide an instance of `Kreait\Firebase\Contract\Messaging` to your FCM message and it will be used in place of the default client.
+
+```php
+public function toFcm(mixed $notifiable)
+{
+    $client = app(\Kreait\Firebase\Contract\Messaging::class);
+
+    return FcmMessage::create()->usingClient($client);
+}
 ```
 
 ## Handling errors

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -23,9 +23,9 @@ class FcmChannel
      * Create a new channel instance.
      *
      * @param  Illuminate\Contracts\Events\Dispatcher  $events
-     * @param  Firebase\Contract\Messaging  $firebase
+     * @param  Firebase\Contract\Messaging  $client
      */
-    public function __construct(protected Dispatcher $events, protected Messaging $firebase) {
+    public function __construct(protected Dispatcher $events, protected Messaging $client) {
         //
     }
 
@@ -48,7 +48,7 @@ class FcmChannel
 
         collect($tokens)
             ->chunk(self::TOKENS_PER_REQUEST)
-            ->map(fn ($tokens) => $this->firebase->sendMulticast($fcmMessage, $tokens->all()))
+            ->map(fn ($tokens) => ($fcmMessage->getClient() ?? $this->client)->sendMulticast($fcmMessage, $tokens->all()))
             ->map(fn (MulticastSendReport $report) => $this->checkReportForFailures($notifiable, $notification, $report));
     }
 

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -25,7 +25,8 @@ class FcmChannel
      * @param  Illuminate\Contracts\Events\Dispatcher  $events
      * @param  Firebase\Contract\Messaging  $client
      */
-    public function __construct(protected Dispatcher $events, protected Messaging $client) {
+    public function __construct(protected Dispatcher $events, protected Messaging $client)
+    {
         //
     }
 

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -4,6 +4,7 @@ namespace NotificationChannels\Fcm;
 
 use Illuminate\Support\Traits\Macroable;
 use Kreait\Firebase\Messaging\Message;
+use Kreait\Firebase\Contract\Messaging;
 use NotificationChannels\Fcm\Exceptions\InvalidPropertyException;
 use NotificationChannels\Fcm\Resources\AndroidConfig;
 use NotificationChannels\Fcm\Resources\ApnsConfig;
@@ -64,6 +65,13 @@ class FcmMessage implements Message
      * @var string|null
      */
     protected $condition;
+
+    /**
+     * The custom messaging client.
+     *
+     * @var \Kreait\Firebase\Contract\Messaging
+     */
+    protected $client;
 
     public static function create(): self
     {
@@ -264,6 +272,29 @@ class FcmMessage implements Message
     public function setCondition(?string $condition): self
     {
         $this->condition = $condition;
+
+        return $this;
+    }
+
+    /**
+     * Get the custom Firebase Messaging client.
+     *
+     * @return  \Kreait\Firebase\Contract\Messaging|null
+     */
+    public function getClient(): ?Messaging
+    {
+        return $this->client;
+    }
+
+    /**
+     * Set the custom Firebase Messaging client instance.
+     *
+     * @param  \Kreait\Firebase\Contract\Messaging  $client
+     * @return $this
+     */
+    public function usingClient(Messaging $client)
+    {
+        $this->client = $client;
 
         return $this;
     }

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -3,8 +3,8 @@
 namespace NotificationChannels\Fcm;
 
 use Illuminate\Support\Traits\Macroable;
-use Kreait\Firebase\Messaging\Message;
 use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Messaging\Message;
 use NotificationChannels\Fcm\Exceptions\InvalidPropertyException;
 use NotificationChannels\Fcm\Resources\AndroidConfig;
 use NotificationChannels\Fcm\Resources\ApnsConfig;
@@ -279,7 +279,7 @@ class FcmMessage implements Message
     /**
      * Get the custom Firebase Messaging client.
      *
-     * @return  \Kreait\Firebase\Contract\Messaging|null
+     * @return \Kreait\Firebase\Contract\Messaging|null
      */
     public function getClient(): ?Messaging
     {


### PR DESCRIPTION
Following the pattern from Laravel's Vonage notification channel, I've added `usingClient` to the `FcmMessage`.