### PR TITLE
Add instructions on storing mobile  FCM token in the database 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ class AccountActivated extends Notification
 }
 ```
 
-You will have to set a `routeNotificationForFcm()` method in your notifiable model. For example:
+You will have to set a `routeNotificationForFcm()` method in your notifiable model.
+This method should return the user's FCM token stored in your database.
+For example:
 
 ```php
 class User extends Authenticatable


### PR DESCRIPTION
This pull request improves the README.md documentation. It clarifies where and how to store the user's FCM token, a crucial piece of information missing from the current documentation could benefit fellow developers.