### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,16 @@ class DeleteExpiredNotificationTokens
      */
     public function handle(NotificationFailed $event): void
     {
-        $report = Arr::get($event->data, 'report');
+        if ($event->channel == FcmChannel::class) {
 
-        $target = $report->target();
+            $report = Arr::get($event->data, 'report');
 
-        $event->notifiable->notificationTokens()
-            ->where('push_token', $target->value())
-            ->delete();
+            $target = $report->target();
+
+            $event->notifiable->notificationTokens()
+                ->where('push_token', $target->value())
+                ->delete();
+        }
     }
 }
 ```


### PR DESCRIPTION
this PR  is to clarify  FCM token invalidation process in README.md 
to get sure that the failed notification channel is `NotificationChannels\Fcm\FcmChannel` 

related to #225 
 
